### PR TITLE
adds validations for presence and length of names [Finishes #134644489]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,4 +24,9 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+  
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :first_name, :length => { :maximum => 30 }
+  validates :last_name, :length => { :maximum => 30 }
 end


### PR DESCRIPTION
Ensure that first_name, last_name are both included when a user signs up.  Limit the length of both to 30 or less.